### PR TITLE
Added jq dependency in readme, which Ubuntu for Windows has not installed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When using [Bash on Ubuntu on Windows](https://msdn.microsoft.com/commandline/ws
 Download the repository by using one of the following commands:
 ```
 # Ubuntu, Bash on Ubuntu on Windows
-sudo apt-get install git binutils pngquant imagemagick librsvg2-bin
+sudo apt-get install git binutils pngquant imagemagick librsvg2-bin jq
 
 # Ubuntu
 git clone https://github.com/picons/picons-source.git ~/picons-source


### PR DESCRIPTION
Ubuntu for Windows has jq not installed by default.