### PR TITLE
Fixed check of missing commands.

### DIFF
--- a/1-build-servicelist.sh
+++ b/1-build-servicelist.sh
@@ -14,7 +14,7 @@ echo -e "\nLog file located at: $logfile\n"
 commands=( sed grep column cat sort find rm wc iconv awk printf )
 
 if [[ -f $location/build-input/tvheadend.serverconf ]]; then
-    commands=( $commands jq curl )
+    commands+=( jq curl )
 fi
 
 for i in ${commands[@]}; do


### PR DESCRIPTION
Hi,
There is a bug when checking for missing commands if `tvheadend.serverconf` exists.

Expanding an array without an index like this only gives the first element, so is equivalent to:  

     commands=( sed jq curl )




